### PR TITLE
Fix uninitialized filter state

### DIFF
--- a/filter_teebee303.h
+++ b/filter_teebee303.h
@@ -20,6 +20,9 @@ public:
     resonanceSkewed = 0.0;
     g = 1.0;
 
+    y1 = y2 = y3 = y4 = 0.0f;
+    hp_x1 = hp_y1 = 0.0f;
+
     twoPiOverSampleRate = 2.0f * PI / AUDIO_SAMPLE_RATE_EXACT;
 
     hp_cutoff = 150.0;
@@ -62,5 +65,4 @@ private:
 
   audio_block_t *inputQueueArray[3];
 };
-
 #endif


### PR DESCRIPTION
## Summary
- zero initialize filter state variables so the filter produces predictable output on startup

## Testing
- `gcc -c filter_teebee303.cpp -I.` *(fails: Arduino.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d8b6cac448333a5a395cc8e705095