### PR TITLE
Fix README grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Teensy-open303-TeeBeeFilter
-Teensy audio filter based on the TeeBeeFilter form the open303 project https://sourceforge.net/projects/open303/
+Teensy audio filter based on the TeeBeeFilter from the open303 project https://sourceforge.net/projects/open303/
 
 This filter has been developed and tested on Teensy 4.1. 
 
-The onePole Highpass filter in the feedbackSignal is been implemented directly within the TeebeeFilter
+The onePole Highpass filter in the feedbackSignal has been implemented directly within the TeebeeFilter
 
 ## TODO
 
-- Look into why the input signal can't more then 50%, else the output signal get's distorted (almost wavefolded).
+- Look into why the input signal can't more than 50%, else the output signal gets distorted (almost wavefolded).
 - Implement external cutoff control
 - Implement external resonance control 


### PR DESCRIPTION
## Summary
- fix a typo in the README for the TeeBee filter description
- update verb tense for filter implementation
- correct wording in TODO about input signal level

## Testing
- `make test` *(fails: No rule to make target)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686d8cabf3b08333aac757a73b8ce973